### PR TITLE
Typehint with interface instead of concrete implementations

### DIFF
--- a/Serializer/JsonSerializer.php
+++ b/Serializer/JsonSerializer.php
@@ -30,7 +30,7 @@ use Avoo\SerializerTranslation\Configuration\Metadata\ClassMetadataInterface;
 use Avoo\SerializerTranslation\Configuration\Metadata\VirtualPropertyMetadata;
 use Avoo\SerializerTranslation\Expression\ExpressionEvaluator;
 use JMS\Serializer\JsonSerializationVisitor;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Jérémy Jégou <jejeavo@gmail.com>
@@ -53,7 +53,7 @@ class JsonSerializer implements JsonSerializerInterface
      * @param Translator          $translator
      * @param ExpressionEvaluator $expressionEvaluator
      */
-    public function __construct(Translator $translator, ExpressionEvaluator $expressionEvaluator)
+    public function __construct(TranslatorInterface $translator, ExpressionEvaluator $expressionEvaluator)
     {
         $this->translator = $translator;
         $this->expressionEvaluator = $expressionEvaluator;

--- a/Serializer/XmlSerializer.php
+++ b/Serializer/XmlSerializer.php
@@ -30,7 +30,7 @@ use Avoo\SerializerTranslation\Configuration\Metadata\ClassMetadataInterface;
 
 use Avoo\SerializerTranslation\Configuration\Metadata\VirtualPropertyMetadata;
 use JMS\Serializer\XmlSerializationVisitor;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Jérémy Jégou <jejeavo@gmail.com>
@@ -39,7 +39,7 @@ class XmlSerializer implements XmlSerializerInterface
 {
     private $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
     }


### PR DESCRIPTION
There are a lot of implementations of the `Symfony\Component\Translation\TranslatorInterface` out there.

Type hinting against the interface makes your code more generic and compatible with any of the concrete implementations.
